### PR TITLE
Switch to VL2016 Update channel

### DIFF
--- a/Office2016PackageBuilder/MS_Office_2016_PKGBuilder.sh
+++ b/Office2016PackageBuilder/MS_Office_2016_PKGBuilder.sh
@@ -32,6 +32,7 @@
 # 2017-01-23 - HTTPS for macadmins.software connection
 # 2017-03-04 - Added Input from @eholtam to suppress OneNote initial dialogs
 # 2018-06-19 - Added support for OneDrive
+# 2018-09-25 - Added change from zone11 to use VL2016 update channel is used (<Office 2019)
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 
@@ -48,7 +49,7 @@ PKG_LANGUAGE="ML"
 MAINURL="https://macadmins.software/versions.xml"
 
 # Get latest version number
-FULL_VERSION=$(curl -s $MAINURL | xmllint --xpath '//latest/o365/text()' -)
+FULL_VERSION=$(curl -s $MAINURL | xmllint --xpath '//latest/vl2016/text()' -)
 
 # Determine working directory
 EXE_DIR=$(dirname "$0")


### PR DESCRIPTION
I suggest switching to "vl2016" update channel to ensure the script gets the installer < 16.17 for _2016 Volume License_ until support for _Microsoft_Office_2019_VL_Serializer.pkg_ is added.